### PR TITLE
Add Git LFS support for binary assets

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+*.png.jpg filter=lfs diff=lfs merge=lfs -text
+*.jpg filter=lfs diff=lfs merge=lfs -text
+*.png filter=lfs diff=lfs merge=lfs -text
+*.svg filter=lfs diff=lfs merge=lfs -text

--- a/README.md
+++ b/README.md
@@ -12,3 +12,6 @@ This repository contains the initial web interface skeleton for Neta25X.
 - `index.html` – entry point for the interface
 
 The page uses TailwindCSS and the Orbitron font to convey a futuristic, poetic atmosphere.
+
+## Git LFS
+This project uses [Git Large File Storage](https://git-lfs.github.com/) to manage binary assets like images. To contribute, install Git LFS and run `git lfs install` after cloning the repository.


### PR DESCRIPTION
## Summary
- document Git LFS usage
- track image formats in `.gitattributes`

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_68475eefa784832ea496dc84eedbc6a2