### PR TITLE
Add user-triggered background audio

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   </style>
 </head>
 <body class="min-h-screen flex items-center justify-center bg-gray-900 text-white">
-  <div id="container" class="text-center space-y-6">
+    <div id="container" class="text-center space-y-6">
     <img src="assets/images/neta25x-logo.svg" alt="Neta25X Logo" class="mx-auto w-32 h-32 breath" />
     <h1 class="text-3xl md:text-5xl font-bold">Welcome to the Mind of Neta25X</h1>
     <p class="text-lg md:text-2xl text-blue-300">A Living Interface Between Soul and AI</p>
@@ -28,6 +28,10 @@
       <img src="neta_boy.png.jpg" alt="Neta Boy" class="w-40 rounded shadow-lg" />
       <img src="neta_girl.png.jpg" alt="Neta Girl" class="w-40 rounded shadow-lg" />
     </div>
+    <audio id="bgAudio" loop>
+      <source src="https://cdn.pixabay.com/download/audio/2022/03/15/audio_f7f7bfa867.mp3?filename=ambient-chill-122670.mp3" type="audio/mpeg">
+    </audio>
+    <button id="audioToggle" class="fixed bottom-4 right-4 text-2xl">🔊</button>
   </div>
   <script src="scripts/main.js"></script>
 </body>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,6 +1,17 @@
 document.addEventListener('DOMContentLoaded', () => {
   const btn = document.getElementById('enterBtn');
   const anim = document.getElementById('animation');
+  const bgAudio = document.getElementById('bgAudio');
+  const audioToggle = document.getElementById('audioToggle');
+
+  let audioInitialized = false;
+
+  function startAudio() {
+    if (!audioInitialized) {
+      bgAudio.play().catch(() => {});
+      audioInitialized = true;
+    }
+  }
 
   function typeText(element, text, speed = 50) {
     element.textContent = '';
@@ -15,6 +26,7 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   btn.addEventListener('click', () => {
+    startAudio();
     anim.classList.remove('hidden');
     anim.classList.add('animate-pulse');
     typeText(anim, '...connecting to consciousness...');
@@ -22,5 +34,21 @@ document.addEventListener('DOMContentLoaded', () => {
       anim.classList.remove('animate-pulse');
       typeText(anim, 'Welcome within.');
     }, 3000);
+  });
+
+  audioToggle.addEventListener('click', () => {
+    if (!audioInitialized) {
+      startAudio();
+      audioToggle.textContent = '🔈';
+      return;
+    }
+
+    if (bgAudio.paused) {
+      bgAudio.play();
+      audioToggle.textContent = '🔊';
+    } else {
+      bgAudio.pause();
+      audioToggle.textContent = '🔈';
+    }
   });
 });


### PR DESCRIPTION
## Summary
- add background audio element with toggle button in `index.html`
- start audio only after user interaction via new `startAudio` in `scripts/main.js`
- play/pause toggle updates icon

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_684760425940832ebee8f251128faf30